### PR TITLE
Store node and topology info, add manifest for virtual environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+dsched-env/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/dsched.py
+++ b/dsched.py
@@ -4,20 +4,27 @@
 #
 
 from server_upcalls import *
-import os
-import select
-import subprocess
+from pmix import PMIxTool
+
+allocation = []
+topologies = []
+
 
 def main():
+    global allocation
+    global topologies
     try:
         dsched = PMIxTool()
-    except:
-        print("FAILED TO CREATE TOOL")
+    except NameError:
+        print("Class PMIxTool is not defined")
         exit(1)
     print("Testing version ", dsched.get_version())
-    args = [{'key':PMIX_SERVER_SCHEDULER, 'value':'T', 'val_type':PMIX_BOOL},
-            {'key':PMIX_CONNECT_TO_SYSTEM, 'value':'T', 'val_type':PMIX_BOOL},
-            {'key':PMIX_TOOL_CONNECT_OPTIONAL, 'value':'T', 'val_type':PMIX_BOOL}]
+    args = [{'key': PMIX_SERVER_SCHEDULER,
+             'value': 'T', 'val_type': PMIX_BOOL},
+            {'key': PMIX_CONNECT_TO_SYSTEM,
+             'value': 'T', 'val_type': PMIX_BOOL},
+            {'key': PMIX_TOOL_CONNECT_OPTIONAL,
+             'value': 'T', 'val_type': PMIX_BOOL}]
     rc, myproc = dsched.init(args)
     print("Init", dsched.error_string(rc), myproc)
     map = {'clientconnected': clientconnected,
@@ -27,24 +34,38 @@ def main():
            'unpublish': clientunpublish,
            'lookup': clientlookup,
            'query': clientquery}
-    my_result = dsched.set_server_module(map)
+    rc = dsched.set_server_module(map)
+    if PMIX_SUCCESS != rc:
+        print("Failed to set server module")
+        exit(1)
 
-    print("Testing PMIx_tool_is_connected")
     rc = dsched.is_connected()
-    print("Connected: ", rc)
+    if not rc:
+        print("Not connected")
+        exit(1)
 
-    # Register a fabric
-    rc,fab = dsched.fabric_register(None)
-    print("Fabric registered: ", dsched.error_string(rc))
-
-    pyq = [{'keys':[PMIX_QUERY_ALLOCATION], 'qualifiers':[]}]
+    pyq = [{'keys': [PMIX_QUERY_ALLOCATION], 'qualifiers':[]}]
     rc, pyresults = dsched.query(pyq)
     if rc != PMIX_SUCCESS and rc != PMIX_OPERATION_SUCCEEDED:
-        print("QUERY TEST FAILED: ", dsched.error_string(rc))
-    print("QUERY INFO RETURNED: ", pyresults)
+        print("QUERY ALLOCATION FAILED: ", dsched.error_string(rc))
+        exit(1)
+    darray = pyresults[0]['value']['array']
+    for d in darray:
+        if PMIX_NODE_INFO.decode() == d['key']:
+            n = d['value']['array']
+            allocation.append(n)
+        elif (PMIX_HWLOC_XML_V2.decode() == d['key'] or
+              PMIX_HWLOC_XML_V1.decode() == d['key']):
+            t = d['value']
+            topologies.append(t)
+        else:
+            print("ALLOCATION CONTAINS UNEXPECTED DATA", d['key'])
 
+    print("ALLOCATION", allocation)
+    print("TOPOLOGIES", topologies)
     print("FINALIZING")
     dsched.finalize()
+
 
 if __name__ == '__main__':
     global killer

--- a/manifest.txt
+++ b/manifest.txt
@@ -1,0 +1,17 @@
+Package     Version
+----------- -------
+asciidoc    10.2.0
+Cython      0.29.32
+flake8      6.0.0
+Mako        1.2.1
+Markdown    3.3.7
+MarkupSafe  2.1.1
+mccabe      0.7.0
+pip         22.3.1
+pluggy      1.0.0
+pycodestyle 2.10.0
+pyflakes    3.0.1
+Pygments    2.12.0
+pypmix      5.0.0
+setuptools  64.0.3
+wheel       0.38.4


### PR DESCRIPTION
Store the returned node and topology information in global arrays for later use. Add a manifest.txt file containing the pip packages to be installed when constructing a virtual DynaSched environment

Signed-off-by: Ralph Castain <rhc@pmix.org>