### PR TITLE
Add project infrastructure: AGENTS.md, code of conduct, and CodeQL

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# DynaSched Community Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the DynaSched project or its community. Examples of representing the project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of the project may be further defined and clarified by DynaSched maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at maintainers@pmix.org. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# CodeQL configuration for DynaSched.  Push / PR scans load this file
+# locally from the checked-out branch.  The scheduled cross-branch scan
+# loads this same file from the default branch via CodeQL's remote
+# config-file syntax, so the release-branch scans do not require a local
+# copy of this file to already exist.
+
+name: "DynaSched CodeQL config"
+
+paths-ignore:
+  - '**/test'
+  # OpenPMIx is cloned here during the manual build; exclude it so
+  # CodeQL only reports results for DynaSched source code.
+  - 'openpmix/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,266 @@
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# CodeQL (GitHub code scanning / static analysis) configuration for
+# DynaSched.
+#
+# What this workflow does:
+#
+#   1. Runs CodeQL analysis on every pull request and on every push
+#      (i.e., merge) to master and the supported release branches.  This
+#      catches newly-introduced problems at the moment code changes.
+#
+#   2. Runs a periodic (weekly, Monday morning UTC) CodeQL scan of master
+#      and the active release branches.
+#
+# Why run periodic scans in addition to the per-PR / per-merge scans?
+#
+#   The PR/merge scans only ever examine code at the moment it changes.
+#   But CodeQL's query packs and analysis engine are continually
+#   updated as new classes of vulnerabilities (and new CVEs) are
+#   discovered.  The weekly scan re-analyzes the *existing* code base
+#   with the latest queries, so a vulnerability pattern that was
+#   unknown when a piece of code was merged can still be found later --
+#   even though that code has not changed and therefore would never be
+#   re-examined by a push/PR scan.  Release branches in particular tend
+#   to go quiet between point releases, so the periodic scan is often
+#   the only thing that keeps their results current.
+#
+# A note on branches and where this file must live:
+#
+#   - push and pull_request workflows always run from the copy of this
+#     file on the branch receiving the push / targeted by the PR (not
+#     from master).  So to get PR and merge analysis on a release branch
+#     (e.g., v1.0.x), this file must also be committed on that branch.
+#
+#   - The schedule (cron) event is special: it only ever fires from the
+#     default branch (master).  To periodically scan the release branches
+#     as well, the scheduled job below explicitly checks out each branch
+#     and tells the analyze action which ref/sha to attribute the results
+#     to.  The scheduled job is therefore inert on the release branches
+#     (it never fires there); only the copy on master drives the weekly
+#     scans.
+#
+# A note on building DynaSched:
+#
+#   DynaSched requires OpenPMIx to be installed before it can be
+#   configured and built.  The manual build steps therefore clone and
+#   install the OpenPMIx master branch before building DynaSched itself.
+
+name: "CodeQL Advanced"
+
+on:
+  push:
+    # Defined once here (&scan_branches) and reused by pull_request
+    # below via a YAML alias, so the two trigger lists cannot drift.
+    branches: &scan_branches
+      - master
+      - 'v[1-9].*'          # Matches v1.0.x, v2.0, v4.1, etc.
+      - 'v[1-9][0-9]+.*'    # Matches v10.0 and higher (double digits+)
+  pull_request:
+    branches: *scan_branches
+  schedule:
+    # Monday morning (UTC).  The off-the-hour minute avoids GitHub's
+    # top-of-the-hour scheduling congestion.
+    - cron: '23 5 * * 1'
+  workflow_dispatch:
+
+permissions:
+  # required for all workflows
+  security-events: write
+  # required to fetch internal or private CodeQL packs
+  packages: read
+  # only required for workflows in private repositories
+  actions: read
+  contents: read
+
+# Cancel a superseded in-progress run when a newer commit is pushed to
+# the same pull request, to avoid stacking up expensive C builds.
+# The group includes the event name so push/schedule runs live in
+# separate groups, and cancellation is enabled only for pull_request
+# runs -- never the weekly scheduled scan or pushes to a branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  # -------------------------------------------------------------------
+  # Event-driven analysis: scans the ref that triggered the push / PR.
+  # -------------------------------------------------------------------
+  analyze:
+    if: >-
+      github.event_name != 'schedule' &&
+      github.event_name != 'workflow_dispatch'
+    name: Analyze ${{ matrix.language }} (${{ github.ref_name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: c-cpp
+            build-mode: manual
+          - language: python
+            build-mode: none
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Install build dependencies
+        if: matrix.build-mode == 'manual'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libhwloc-dev libevent-dev \
+            autoconf automake libtool
+
+      - name: Clone and build OpenPMIx
+        if: matrix.build-mode == 'manual'
+        uses: actions/checkout@v4
+        with:
+          repository: openpmix/openpmix
+          ref: master
+          path: openpmix/master
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Install OpenPMIx
+        if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          cd openpmix/master
+          ./autogen.pl
+          ./configure --prefix=$RUNNER_TEMP/pmixinstall
+          make -j $(nproc)
+          make install
+
+      - name: Build DynaSched
+        if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          ./autogen.pl
+          ./configure --prefix=$RUNNER_TEMP/dschedinstall \
+            --with-pmix=$RUNNER_TEMP/pmixinstall
+          make -j $(nproc)
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"
+
+  # -------------------------------------------------------------------
+  # Scheduled/manual analysis: explicitly scans master and each release
+  # branch. The schedule only fires from the default branch (master);
+  # see the header comment. workflow_dispatch intentionally runs this
+  # same matrix so the scheduled path can be tested without waiting for
+  # the next cron event.
+  # -------------------------------------------------------------------
+  analyze-scheduled:
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch'
+    name: Scheduled analysis - ${{ matrix.language }} (${{ matrix.branch }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Concrete branch names only: this matrix drives
+        # 'actions/checkout', so (unlike the on.push.branches globs)
+        # these cannot be globs or regexes. New release branches must be
+        # added here, too.
+        branch:
+          - master
+        language:
+          - actions
+          - c-cpp
+          - python
+        include:
+          - language: actions
+            build-mode: none
+          - language: c-cpp
+            build-mode: manual
+          - language: python
+            build-mode: none
+    steps:
+      - name: Checkout ${{ matrix.branch }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Resolve commit SHA
+        id: commit
+        shell: bash
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: >-
+            ${{ github.repository }}/.github/codeql/codeql-config.yml@${{ github.event.repository.default_branch }}
+
+      - name: Install build dependencies
+        if: matrix.build-mode == 'manual'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libhwloc-dev libevent-dev \
+            autoconf automake libtool
+
+      - name: Clone and build OpenPMIx
+        if: matrix.build-mode == 'manual'
+        uses: actions/checkout@v4
+        with:
+          repository: openpmix/openpmix
+          ref: master
+          path: openpmix/master
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Install OpenPMIx
+        if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          cd openpmix/master
+          ./autogen.pl
+          ./configure --prefix=$RUNNER_TEMP/pmixinstall
+          make -j $(nproc)
+          make install
+
+      - name: Build DynaSched
+        if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          ./autogen.pl
+          ./configure --prefix=$RUNNER_TEMP/dschedinstall \
+            --with-pmix=$RUNNER_TEMP/pmixinstall
+          make -j $(nproc)
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"
+          # Attribute results to the checked-out branch rather than to
+          # master (which is what a schedule event would otherwise report
+          # against).
+          ref: refs/heads/${{ matrix.branch }}
+          sha: ${{ steps.commit.outputs.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,9 @@ docs/_static
 docs/_static/css/custom.css
 docs/_templates
 
+# Generated RST files
+docs/code-of-conduct.rst
+
 # tools
 src/tools/dsched/dsched
 src/tools/dsched_info/dsched-info

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,6 +12,9 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.13"
+  jobs:
+    pre_build:
+      - python3 docs/generate-code-of-conduct-rst.py --input .github/CODE_OF_CONDUCT.md --output docs/code-of-conduct.rst
 
 python:
   install:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,262 @@
+# AGENTS.md — Orientation for AI Coding Agents and Human Contributors
+
+This document is an orientation guide for AI coding agents and human contributors working in the DynaSched codebase. It is a map, not comprehensive documentation; authoritative detail lives in `docs/` and in the header files under `src/`.
+
+AI-assisted contributions are welcome. DynaSched targets HPC environments running on diverse hardware and operating systems. Write portable, standards-conforming C11 code and avoid shortcuts that work on one platform but silently break on another.
+
+---
+
+## What is DynaSched?
+
+DynaSched (Dynamic Scheduler Platform) is an open-source, PMIx-native resource scheduler designed for HPC environments. It operates as a daemon (`dsched`) that accepts allocation requests from PMIx clients, computes schedules using pluggable algorithms, and returns allocation decisions — all built on top of the PMIx infrastructure.
+
+Repository: https://github.com/dynasched/dynasched
+
+---
+
+## Terminology
+
+- **MCA**: Modular Component Architecture — the plugin system inherited from the PMIx/PRRTE ecosystem
+- **framework**: An MCA abstraction layer defining a functional area's interface (e.g., `dsched`, `dmetric`, `dmeta`)
+- **component**: A plugin implementing a framework interface
+- **module**: The active component instance after MCA selection
+- **session**: A resource allocation session tracking nodes assigned to a user request (`dsched_session_t`)
+- **meta**: A scheduling meta-request object (`dsched_meta_t`) carrying a request through the scheduling pipeline
+- **caddy**: A heap-allocated callback object used to carry context across thread-shift boundaries (`dsched_shift_caddy_t`)
+- **evbase**: An event base (`dsched_event_base_t`) wrapping a libevent `event_base` used for async dispatch
+- **PMIX_NEW / PMIX_RELEASE**: PMIx object lifecycle macros (reference-counted allocation and release)
+
+---
+
+## User-Facing Tools
+
+| Tool | Source | Purpose |
+|------|--------|---------|
+| `dsched` | `src/tools/dsched/` | The scheduler daemon — accepts and services allocation requests |
+| `dsched_info` | `src/tools/dsched_info/` | Query configuration and list available components |
+
+---
+
+## Source Layout
+
+```
+src/
+  tools/          # Executable entry points (dsched daemon, dsched_info)
+  mca/            # MCA frameworks and their components
+  runtime/        # Global state initialization, progress threads
+  util/           # Internal utilities (error handling, attrs, session dirs)
+  include/        # Internal headers (globals, constants, types, config)
+  event/          # Libevent integration
+```
+
+Central data structures (`dsched_session_t`, `dsched_node_t`, `dsched_meta_t`, `dsched_shift_caddy_t`, `dsched_globals_t`) are defined in `src/include/dsched_globals.h`.
+
+---
+
+## MCA Frameworks
+
+| Framework | Location | Responsibility |
+|-----------|----------|----------------|
+| `dsched` | `src/mca/dsched/` | Core scheduling algorithm (compute an allocation from a request) |
+| `dmetric` | `src/mca/dmetric/` | Resource metric collection (e.g., energy) |
+| `dmeta` | `src/mca/dmeta/` | Meta-scheduling — prioritize and order pending requests |
+| `dlog` | `src/mca/dlog/` | Logging subsystem |
+| `ddl` | `src/mca/ddl/` | Dynamic linker abstraction |
+| `dinstalldirs` | `src/mca/dinstalldirs/` | Installation directory queries |
+
+### Currently Available Components
+
+| Framework | Component | Location | Notes |
+|-----------|-----------|----------|-------|
+| `dsched` | `fifo` | `src/mca/dsched/fifo/` | First-in, first-out scheduler |
+| `dmetric` | `energy` | `src/mca/dmetric/energy/` | Energy-aware metric collection |
+| `dmeta` | `pri` | `src/mca/dmeta/pri/` | Priority-based meta-scheduler |
+
+### Component Structure
+
+Each component requires:
+- `<framework>.h` — the framework-level header defining the module struct
+- `<component>.h` — component-local header exporting the component and module structs
+- `<component>.c` — module implementation
+- `<component>_component.c` — MCA registration, open, query, close
+- `Makefile.am`
+
+Selection follows standard MCA priority rules: the highest-priority component that opens successfully becomes the active module.
+
+---
+
+## DynaSched's Relationship with PMIx
+
+DynaSched depends on PMIx (minimum version 6.1.0) and uses PMIx internals directly — this is distinct from calling the PMIx public API.
+
+**From PMIx, DynaSched uses:**
+- MCA infrastructure (`src/mca/base/pmix_base.h`, `src/mca/mca.h`)
+- Data structures (`pmix_list_t`, `pmix_pointer_array_t`, `pmix_object_t`)
+- Threading primitives (`pmix_mutex_t`, `pmix_lock_t`, `PMIX_WAKEUP_THREAD`)
+- Utility functions (`pmix_argv_*`, `pmix_output_*`, `pmix_show_help`)
+- Event loop integration (libevent via PMIx's event abstraction)
+- Memory management (`PMIX_NEW`, `PMIX_RELEASE`)
+
+---
+
+## Coding Rules
+
+### Mandatory Header Order
+
+`dsched_config.h` **must be the first `#include`** in every `.c` file:
+
+```c
+#include "dsched_config.h"
+
+#include <sys/types.h>
+...
+#include "src/include/dsched_globals.h"
+```
+
+### Symbol Prefixes
+
+| Scope | Prefix |
+|-------|--------|
+| Exported macros | `DSCHED_` |
+| Exported functions and types | `dsched_` |
+| MCA component symbols | `dsched_<framework>_<component>_` |
+| Internal (not exported) | `dsched_` without `DSCHED_EXPORT` |
+
+Do not use `PMIX_` or `pmix_` prefixes for new DynaSched symbols.
+
+### Copyright Header
+
+New files require the standard multi-institution BSD copyright block with `$COPYRIGHT$` and `$HEADER$` tokens, matching the pattern in existing files.
+
+### Macro Definitions
+
+Define logical macros to `0` or `1`; never `#undef` them. Test with `#if FOO`, not `#ifdef FOO`.
+
+### Constant-on-Left Comparisons
+
+```c
+if (NULL == ptr)              /* correct */
+if (DSCHED_SUCCESS == rc)     /* correct */
+```
+
+### Bracing
+
+Always use `{ }` around every conditional or loop body, including single-statement ones.
+
+### Indentation
+
+4 spaces, never tab characters.
+
+### Compiler Warnings
+
+Aim for zero compiler warnings. Use `DSCHED_HIDE_UNUSED_PARAMS(...)` for intentionally unused parameters rather than casting to void or suppressing warnings with flags.
+
+### Generated Files
+
+Do not hand-edit files produced by autotools or files vendored from PMIx. Edit the upstream source (`.m4`, `.am`, `.ac`) instead.
+
+### Error Handling
+
+Functions that can fail return `int`. Check every return value. Use `DSCHED_SUCCESS` / `DSCHED_ERROR` return codes and the appropriate output/logging calls for unexpected errors.
+
+### Thread Model and Event Loop
+
+DynaSched is event-driven. The main progress thread runs a libevent loop. Do not block on the progress thread. Schedule deferred work using `DSCHED_THREADSHIFT`.
+
+The `fifo` scheduler component demonstrates the pattern: work is dispatched to a dedicated per-component event base (`dsched_progress_thread_init`) and results are shifted back to the main event base (`dsched_globals.evbase`) via `DSCHED_THREADSHIFT`.
+
+### Thread-Shifting with Caddies
+
+A **caddy** (`dsched_shift_caddy_t`) carries request context across thread-shift boundaries. Pattern:
+
+1. Allocate with `PMIX_NEW(dsched_shift_caddy_t)`
+2. Assign the relevant fields (do not copy — just point)
+3. Call `DSCHED_THREADSHIFT(cd, evbase, handler_fn)`
+4. The target event base fires `handler_fn` on the correct thread
+
+Required caddy fields:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `ev` | `dsched_event_t` | Libevent handle — must be named `ev` |
+| `mt` | `dsched_meta_t *` | The meta-request being scheduled |
+| `alloc` | `dsched_alloc_t *` | Allocation result being built |
+| `evcbfunc` | `dsched_event_cbfunc_fn_t` | Callback when scheduling completes |
+
+Never allocate caddies on the stack; they must outlive the creating stack frame.
+
+### Memory Management
+
+Use `PMIX_NEW` / `PMIX_RELEASE` for objects that embed `pmix_object_t`. Use `malloc`/`free` for plain C structs that do not need reference counting.
+
+### C Standard
+
+DynaSched targets C11. Fix compiler warnings at their source; do not add `-Wno-*` flags.
+
+---
+
+## Build System
+
+DynaSched uses GNU Autotools. The `configure` script is not checked in; generate it with:
+
+```bash
+./autogen.pl
+./configure [options]
+make -j$(nproc)
+make install
+```
+
+### Common Configure Options
+
+| Option | Purpose |
+|--------|---------|
+| `--with-pmix=<path>` | Path to PMIx installation |
+| `--with-hwloc=<path>` | Path to hwloc installation |
+| `--with-libevent=<path>` | Path to libevent installation |
+| `--enable-debug` | Build with debug symbols and assertions |
+| `--enable-devel-check` | Treat compiler warnings as errors |
+
+**Minimum dependency versions** (from `VERSION`):
+
+| Dependency | Minimum |
+|------------|---------|
+| PMIx | 6.1.0 |
+| hwloc | 2.1.0 |
+| libevent | 2.0.21 |
+| autoconf | 2.69.0 |
+| automake | 1.13.4 |
+| libtool | 2.4.2 |
+
+---
+
+## Contributing
+
+### Commit Messages
+
+Write prose commit messages, not bullet lists. The subject line should complete "If applied, this commit will …". The body must explain **why** the change is needed, not just what it does. Keep subject lines under 72 characters.
+
+All commits require `Signed-off-by:` (DCO):
+```bash
+git commit -s
+```
+
+### Pull Requests
+
+- Open PRs against the `master` branch
+- One logical change per PR
+- Describe the problem in the PR description, not just the solution
+- Update `docs/` for any user-visible change
+
+### Testing
+
+Run the daemon directly to smoke-test changes:
+
+```bash
+./dsched &        # start the scheduler daemon
+# submit a test allocation request via a PMIx client
+kill %1           # shut down
+```
+
+### Reporting Bugs
+
+File issues at https://github.com/dynasched/dynasched/issues. Include the output of `dsched_info --all` and a minimal reproduction case.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -31,6 +31,9 @@ OUTDIR             = _build
 SPHINX_CONFIG      = conf.py
 SPHINX_OPTS       ?= -W --keep-going -j auto
 
+MARKDOWN_SOURCE_FILES = \
+        $(top_srcdir)/.github/CODE_OF_CONDUCT.md
+
 # Note: it is significantly more convenient to list all the source
 # files here using wildcards (vs. listing every single .rst file).
 # However, it is necessary to list $(srcdir) when using wildcards.
@@ -56,7 +59,9 @@ RST_SOURCE_FILES   = \
 
 EXTRA_DIST         = \
         requirements.txt \
+        generate-code-of-conduct-rst.py \
         $(SPHINX_CONFIG) \
+        $(MARKDOWN_SOURCE_FILES) \
         $(TEXT_SOURCE_FILES) \
         $(IMAGE_SOURCE_FILES) \
         $(RST_SOURCE_FILES) \
@@ -105,6 +110,10 @@ if DSCHED_BUILD_DOCS
 
 include $(top_srcdir)/Makefile.dsched-rules
 
+# Generate this file from CODE_OF_CONDUCT.md as part of the Sphinx
+# docs build.
+CODE_OF_CONDUCT_RST = $(srcdir)/code-of-conduct.rst
+
 # Have to not list these targets in EXTRA_DIST outside of the
 # DSCHED_BUILD_DOCS conditional because "make dist" will fail due to
 # these missing targets (and therefore not run the "dist-hook" target
@@ -121,6 +130,12 @@ ALL_MAN_BUILT = \
         $(DSCHED_MAN1_BUILT) $(DSCHED_MAN7_BUILT)
 $(ALL_MAN_BUILT): $(RST_SOURCE_FILES) $(IMAGE_SOURCE_FILES)
 $(ALL_MAN_BUILT): $(TEXT_SOURCE_FILES) $(SPHINX_CONFIG)
+$(ALL_MAN_BUILT): $(CODE_OF_CONDUCT_RST)
+
+$(CODE_OF_CONDUCT_RST): $(top_srcdir)/.github/CODE_OF_CONDUCT.md
+$(CODE_OF_CONDUCT_RST): generate-code-of-conduct-rst.py
+	$(DSCHED_V_GEN) python3 $(srcdir)/generate-code-of-conduct-rst.py \
+		--input $(top_srcdir)/.github/CODE_OF_CONDUCT.md --output $@
 
 # List both commands (HTML and man) in a single rule because they
 # really need to be run in serial.  Specifically, if they were two
@@ -142,12 +157,13 @@ linkcheck:
 
 maintainer-clean-local:
 	$(SPHINX_BUILD) -M clean "$(srcdir)" "$(OUTDIR)" $(SPHINX_OPTS)
+	rm -f $(CODE_OF_CONDUCT_RST)
 
 # List all the built man pages here in the Automake BUILT_SOURCES
 # macro.  This hooks into the normal Automake build mechanisms, and
 # will ultimately cause the invocation of the above rule that runs
 # Sphinx to build the HTML and man pages.
-BUILT_SOURCES = $(ALL_MAN_BUILT)
+BUILT_SOURCES = $(CODE_OF_CONDUCT_RST) $(ALL_MAN_BUILT)
 
 endif DSCHED_BUILD_DOCS
 

--- a/docs/generate-code-of-conduct-rst.py
+++ b/docs/generate-code-of-conduct-rst.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+"""Convert DynaSched's Markdown CODE_OF_CONDUCT.md to reStructuredText."""
+
+import argparse
+import re
+from pathlib import Path
+
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*#*\s*$")
+REF_DEF_RE = re.compile(r"^\[([^\]]+)\]:\s*(\S+)\s*$")
+REF_LINK_RE = re.compile(r"\[([^\]]+)\]\[([^\]]+)\]")
+INLINE_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+BULLET_RE = re.compile(r"^\s*[*+-]\s+")
+UNDERLINES = ["=", "-", "~", "^", '"', "'"]
+
+
+def _rst_link(text, url):
+    return "`{} <{}>`_".format(text, url)
+
+
+def _convert_links(line, refs):
+    def repl_ref(match):
+        text = match.group(1)
+        ref = match.group(2)
+        return _rst_link(text, refs.get(ref, ref))
+
+    def repl_inline(match):
+        return _rst_link(match.group(1), match.group(2))
+
+    line = REF_LINK_RE.sub(repl_ref, line)
+    line = INLINE_LINK_RE.sub(repl_inline, line)
+    return line
+
+
+def convert(lines):
+    refs = {}
+    for line in lines:
+        match = REF_DEF_RE.match(line.strip())
+        if match:
+            refs[match.group(1)] = match.group(2)
+
+    out = [
+        "..",
+        "   This file was generated from .github/CODE_OF_CONDUCT.md by docs/Makefile.am.",
+        "   Do not edit directly.",
+        "",
+    ]
+
+    skip_next_blank = False
+    prev_bullet = False
+    for line in lines:
+        if REF_DEF_RE.match(line.strip()):
+            continue
+        if skip_next_blank and not line.strip():
+            skip_next_blank = False
+            continue
+        skip_next_blank = False
+
+        match = HEADING_RE.match(line)
+        if match:
+            if out and out[-1] != "":
+                out.append("")
+            title = _convert_links(match.group(2), refs)
+            level = min(len(match.group(1)) - 1, len(UNDERLINES) - 1)
+            out.extend([title, UNDERLINES[level] * len(title), ""])
+            skip_next_blank = True
+            prev_bullet = False
+        else:
+            is_bullet = bool(BULLET_RE.match(line))
+            if is_bullet and out and out[-1] != "" and not prev_bullet:
+                out.append("")
+            out.append(_convert_links(line, refs))
+            prev_bullet = is_bullet
+
+    while out and out[-1] == "":
+        out.pop()
+    return "\n".join(out) + "\n"
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        convert(input_path.read_text(encoding="utf-8").splitlines()),
+        encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,7 @@ Table of contents
    quickstart.rst
    developers/index.rst
    contributing.rst
+   code-of-conduct.rst
    license.rst
    getting-help.rst
    installing-dsched/index.rst


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` (with `CLAUDE.md` symlink) to orient AI coding agents and human contributors to the codebase layout, MCA framework structure, coding conventions, and build system
- Add a community Code of Conduct (Contributor Covenant 1.4) under `.github/CODE_OF_CONDUCT.md`, with a Python conversion script and Makefile/ReadTheDocs integration to publish it via Sphinx
- Add CodeQL static analysis via GitHub Actions: per-push/PR scanning of master and release branches, plus a weekly scheduled scan to catch newly-discovered vulnerability patterns in existing code

## Test plan

- [ ] Verify `CLAUDE.md` symlink resolves to `AGENTS.md`
- [ ] Verify `docs/generate-code-of-conduct-rst.py --input .github/CODE_OF_CONDUCT.md --output docs/code-of-conduct.rst` produces valid RST
- [ ] Verify CodeQL workflow runs on PR (Actions tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)